### PR TITLE
Symlinks

### DIFF
--- a/wnfs-common/src/metadata.rs
+++ b/wnfs-common/src/metadata.rs
@@ -235,14 +235,7 @@ impl TryFrom<&str> for NodeType {
 
 impl From<&NodeType> for String {
     fn from(r#type: &NodeType) -> Self {
-        match r#type {
-            NodeType::PrivateDirectory => "wnfs/priv/dir".into(),
-            NodeType::PrivateFile => "wnfs/priv/file".into(),
-            NodeType::PublicDirectory => "wnfs/pub/dir".into(),
-            NodeType::PublicFile => "wnfs/pub/file".into(),
-            NodeType::TemporalSharePointer => "wnfs/share/temporal".into(),
-            NodeType::SnapshotSharePointer => "wnfs/share/snapshot".into(),
-        }
+        r#type.to_string()
     }
 }
 

--- a/wnfs/src/private/directory.rs
+++ b/wnfs/src/private/directory.rs
@@ -6,7 +6,7 @@ use crate::{error::FsError, traits::Id, SearchResult};
 use anyhow::{bail, ensure, Result};
 use async_once_cell::OnceCell;
 use chrono::{DateTime, Utc};
-use libipld::Cid;
+use libipld::{Cid, Ipld};
 use rand_core::RngCore;
 use semver::Version;
 use serde::{de::Error as DeError, ser::Error as SerError, Deserialize, Deserializer, Serialize};
@@ -917,6 +917,51 @@ impl PrivateDirectory {
         let _ = self
             .get_or_create_leaf_dir_mut(path_segments, time, search_latest, forest, store, rng)
             .await?;
+
+        Ok(())
+    }
+
+    /// Write a Symlink to the filesystem with the reference path at the path segments specified
+    pub async fn write_symlink(
+        self: &mut Rc<Self>,
+        path: String,
+        path_segments: &[String],
+        search_latest: bool,
+        time: DateTime<Utc>,
+        forest: &PrivateForest,
+        store: &impl BlockStore,
+        rng: &mut impl RngCore,
+    ) -> Result<()> {
+        let (path_segments, filename) = crate::utils::split_last(path_segments)?;
+
+        let dir = self
+            .get_or_create_leaf_dir_mut(path_segments, time, search_latest, forest, store, rng)
+            .await?;
+
+        match dir
+            .lookup_node_mut(filename, search_latest, forest, store)
+            .await?
+        {
+            Some(PrivateNode::File(file)) => {
+                let file = file.prepare_next_revision()?;
+                file.content.content = super::FileContent::Inline { data: vec![] };
+                file.content.metadata.upsert_mtime(time);
+                // Write the path into the Metadata HashMap
+                file.content.metadata.0.insert(String::from("symlink"), Ipld::String(path));
+            }
+            Some(PrivateNode::Dir(_)) => bail!(FsError::DirectoryAlreadyExists),
+            None => {
+                let file = PrivateFile::new_symlink(
+                    path,
+                    dir.header.bare_name.clone(),
+                    time,
+                    rng,
+                )
+                .await?;
+                let link = PrivateLink::with_file(file);
+                dir.content.entries.insert(filename.to_string(), link);
+            }
+        };
 
         Ok(())
     }

--- a/wnfs/src/private/directory.rs
+++ b/wnfs/src/private/directory.rs
@@ -922,6 +922,7 @@ impl PrivateDirectory {
     }
 
     /// Write a Symlink to the filesystem with the reference path at the path segments specified
+    #[allow(clippy::too_many_arguments)]
     pub async fn write_symlink(
         self: &mut Rc<Self>,
         path: String,
@@ -947,17 +948,15 @@ impl PrivateDirectory {
                 file.content.content = super::FileContent::Inline { data: vec![] };
                 file.content.metadata.upsert_mtime(time);
                 // Write the path into the Metadata HashMap
-                file.content.metadata.0.insert(String::from("symlink"), Ipld::String(path));
+                file.content
+                    .metadata
+                    .0
+                    .insert(String::from("symlink"), Ipld::String(path));
             }
             Some(PrivateNode::Dir(_)) => bail!(FsError::DirectoryAlreadyExists),
             None => {
-                let file = PrivateFile::new_symlink(
-                    path,
-                    dir.header.bare_name.clone(),
-                    time,
-                    rng,
-                )
-                .await?;
+                let file =
+                    PrivateFile::new_symlink(path, dir.header.bare_name.clone(), time, rng).await?;
                 let link = PrivateLink::with_file(file);
                 dir.content.entries.insert(filename.to_string(), link);
             }

--- a/wnfs/src/private/file.rs
+++ b/wnfs/src/private/file.rs
@@ -8,7 +8,7 @@ use async_once_cell::OnceCell;
 use async_stream::try_stream;
 use chrono::{DateTime, Utc};
 use futures::{future, AsyncRead, Stream, StreamExt};
-use libipld::{Cid, IpldCodec, Ipld};
+use libipld::{Cid, Ipld, IpldCodec};
 use rand_core::RngCore;
 use semver::Version;
 use serde::{de::Error as DeError, Deserialize, Deserializer, Serialize};
@@ -356,7 +356,9 @@ impl PrivateFile {
         // Create a new Metadata object
         let mut metadata: Metadata = Metadata::new(time);
         // Write the original path into the Metadata HashMap
-        metadata.0.insert(String::from("symlink"), Ipld::String(path));
+        metadata
+            .0
+            .insert(String::from("symlink"), Ipld::String(path));
         // Return self with PrivateFileContent
         Ok(Self {
             header,
@@ -736,8 +738,7 @@ impl PrivateFile {
         // If the Metadata contains a String key for the symlink
         if let Some(Ipld::String(path)) = meta.0.get("symlink") {
             Some(path.to_string())
-        }
-        else {
+        } else {
             None
         }
     }

--- a/wnfs/src/private/file.rs
+++ b/wnfs/src/private/file.rs
@@ -8,7 +8,7 @@ use async_once_cell::OnceCell;
 use async_stream::try_stream;
 use chrono::{DateTime, Utc};
 use futures::{future, AsyncRead, Stream, StreamExt};
-use libipld::{Cid, IpldCodec};
+use libipld::{Cid, IpldCodec, Ipld};
 use rand_core::RngCore;
 use semver::Version;
 use serde::{de::Error as DeError, Deserialize, Deserializer, Serialize};
@@ -339,6 +339,33 @@ impl PrivateFile {
                     }
                 }
             }
+        })
+    }
+
+    /// Create a new Symlink PrivateFile
+    pub async fn new_symlink(
+        path: String,
+        parent_bare_name: Namefilter,
+        time: DateTime<Utc>,
+        rng: &mut impl RngCore,
+    ) -> Result<Self> {
+        // Header stays the same
+        let header = PrivateNodeHeader::new(parent_bare_name, rng);
+        // Symlinks have no file content
+        let content = FileContent::Inline { data: vec![] };
+        // Create a new Metadata object
+        let mut metadata: Metadata = Metadata::new(time);
+        // Write the original path into the Metadata HashMap
+        metadata.0.insert(String::from("symlink"), Ipld::String(path));
+        // Return self with PrivateFileContent
+        Ok(Self {
+            header,
+            content: PrivateFileContent {
+                persisted_as: OnceCell::new(),
+                metadata,
+                previous: BTreeSet::new(),
+                content,
+            },
         })
     }
 
@@ -701,6 +728,18 @@ impl PrivateFile {
     /// Wraps the file in a [`PrivateNode`].
     pub fn as_node(self: &Rc<Self>) -> PrivateNode {
         PrivateNode::File(Rc::clone(self))
+    }
+
+    /// If the Metadata contains Symlink data, return it
+    pub fn symlink_origin(&self) -> Option<String> {
+        let meta = self.get_metadata();
+        // If the Metadata contains a String key for the symlink
+        if let Some(Ipld::String(path)) = meta.0.get("symlink") {
+            Some(path.to_string())
+        }
+        else {
+            None
+        }
     }
 }
 

--- a/wnfs/src/private/node/header.rs
+++ b/wnfs/src/private/node/header.rs
@@ -45,7 +45,7 @@ pub struct PrivateNodeHeader {
     /// A unique identifier of the node.
     pub(crate) inumber: INumber,
     /// Used both for versioning and deriving keys for that enforces privacy.
-    pub(crate) ratchet: Ratchet,
+    pub ratchet: Ratchet,
     /// Used for ancestry checks and as a key for the private forest.
     pub(crate) bare_name: Namefilter,
 }


### PR DESCRIPTION
Modified the `PrivateDirectory` API such that the `Metadata` `BTreeMap` can be interfaced with to store symlink paths, using `PrivateFiles` with empty contents. 
I have also made public the `Ratchet` field of the `header` of `PrivateNode`s, such that they can be tracked manually in `tomb` while `TemporalSharePointer` and `PrivateNodeOnPathHistory::of` are being overhauled. Once they can be interfaced with reliably in ways that do not require the exposure this field, we will revert this specific change. 