### PR TITLE
CarBlockStore modifications

### DIFF
--- a/wnfs-common/src/blockstore/carblockstore.rs
+++ b/wnfs-common/src/blockstore/carblockstore.rs
@@ -1,7 +1,8 @@
 use crate::BlockStore;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
-use libipld::{Cid, IpldCodec};
+use libipld::{Cid, IpldCodec, cbor::{cbor, DagCbor, DagCborCodec}, prelude::Codec, ipld, Ipld};
+use multihash::{Code, MultihashDigest};
 use serde::{Deserialize, Serialize, Serializer};
 use std::{
     borrow::Cow,
@@ -10,10 +11,13 @@ use std::{
     io::{BufWriter, Read, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
     str::FromStr,
-    sync::RwLock,
+    sync::RwLock, vec,
 };
 
+
 pub struct CarBlockStore {
+    /// The version number and list of root dir CIDs
+    carhead: CarHeader,
     /// The number of bytes that each CAR file can hold.
     max_size: Option<usize>,
     /// Index of which blocks are in which files (by CAR number), and the offset in the file.
@@ -26,14 +30,15 @@ impl Serialize for CarBlockStore {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
-    {
+    {   
+        let header_bytes = self.carhead.to_bytes();
         let mut string_keyed_index: HashMap<String, &LocationInCar> = HashMap::new();
         let binding = self.index.read().unwrap();
         for (k, v) in binding.iter() {
             string_keyed_index.insert(k.to_string(), v);
         }
 
-        (self.max_size, &string_keyed_index, &self.car_factory).serialize(serializer)
+        (header_bytes, self.max_size, &string_keyed_index, &self.car_factory).serialize(serializer)
     }
 }
 
@@ -43,12 +48,13 @@ impl<'de> Deserialize<'de> for CarBlockStore {
         D: serde::Deserializer<'de>,
     {
         // Deserialize the path
-        let (max_size, string_keyed_index, car_factory) = <(
+        let (header_bytes, max_size, string_keyed_index, car_factory) = <(
+            Vec<u8>,
             Option<usize>,
             HashMap<String, LocationInCar>,
             RwLock<DiskCarFactory>,
         )>::deserialize(deserializer)?;
-
+        let carhead = CarHeader::from_bytes(&header_bytes);
         let mut index: HashMap<Cid, LocationInCar> = HashMap::new();
         for (k, v) in string_keyed_index.into_iter() {
             let cid = Cid::from_str(&k).unwrap();
@@ -59,6 +65,7 @@ impl<'de> Deserialize<'de> for CarBlockStore {
 
         // Return Ok status with the new DiskBlockStore
         Ok(Self {
+            carhead,
             max_size,
             index,
             car_factory,
@@ -73,12 +80,15 @@ impl CarBlockStore {
         let _ = std::fs::create_dir_all(directory);
         // Create the directory
         std::fs::create_dir_all(directory).unwrap();
-        // Create the CAR file factory
-        let car_factory = DiskCarFactory::new(directory);
+        // Create the CAR Header
+        let carhead = CarHeader::new();
         // Create the indexer
         let index = RwLock::new(HashMap::new());
+        // Create the CAR file factory
+        let car_factory = DiskCarFactory::new(directory);
         // Instantiate the block store
         Self {
+            carhead,
             max_size,
             index,
             car_factory: RwLock::new(car_factory),
@@ -93,6 +103,14 @@ impl CarBlockStore {
         factory.directory = new_directory.to_path_buf();
         // Return OK
         Ok(())
+    }
+
+    pub fn add_root(&mut self, cid: &Cid) {
+        self.carhead.roots.push(*cid);
+    }
+
+    pub fn get_roots(&self) -> Vec<Cid> {
+        self.carhead.roots.clone()
     }
 }
 
@@ -207,6 +225,46 @@ impl BlockStore for CarBlockStore {
 
         // Return generated CID for future retrieval
         Ok(cid)
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct CarHeader {
+    version: i128,
+    roots: Vec<Cid>
+}
+
+impl CarHeader {
+    pub fn new() -> Self {
+        Self {
+            version: 1,
+            roots: Vec::new()
+        }
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let roots = Ipld::List(
+            self.roots.clone().into_iter().map(|r| Ipld::Link(r)).collect()
+        );
+        let header_ipld: Ipld = ipld!({
+            "version": self.version,
+            "roots": roots,
+          });
+        DagCborCodec.encode(&header_ipld).unwrap()
+    }
+
+    pub fn from_bytes(bytes: &Vec<u8>) -> Self {
+        let header_ipld: Ipld = DagCborCodec.decode(bytes).unwrap();
+        let Ipld::Integer(version) = header_ipld.get("version").unwrap() else { panic!() };
+        let Ipld::List(roots) = header_ipld.get("roots").unwrap() else { panic!() };
+
+        let roots: Vec<Cid> = roots.into_iter().map(|ipld| {
+            let Ipld::Link(cid) = ipld else { panic!() }; 
+            *cid
+        })
+        .collect();
+
+        CarHeader { version: *version, roots }
     }
 }
 

--- a/wnfs/src/private/node/header.rs
+++ b/wnfs/src/private/node/header.rs
@@ -45,7 +45,7 @@ pub struct PrivateNodeHeader {
     /// A unique identifier of the node.
     pub(crate) inumber: INumber,
     /// Used both for versioning and deriving keys for that enforces privacy.
-    pub ratchet: Ratchet,
+    pub(crate) ratchet: Ratchet,
     /// Used for ancestry checks and as a key for the private forest.
     pub(crate) bare_name: Namefilter,
 }


### PR DESCRIPTION
Modified the CarBlockStore to include a header full of DAG CBOR IPLD bytes which refer to the version number and root CIDs encoded in the BlockStore. 