### PR TITLE
fix: use zeroed ratchet on snapshot

### DIFF
--- a/wnfs/src/private/node/header.rs
+++ b/wnfs/src/private/node/header.rs
@@ -310,7 +310,7 @@ impl PrivateNodeHeader {
 
         Ok(Self {
             inumber,
-            ratchet: Ratchet::default(),
+            ratchet: Ratchet::zero([0; 32]),
             bare_name,
         })
     }


### PR DESCRIPTION
Makes the generated skip-ratchet on snapshot of file use actual Zeroed ratchet. 

Allows calls to load a snapshot succeed in wasm: there is some bad use of the random crate which exists in the default Skip Ratchet initializer which doesn't work in wasm

A full solution would address that -- this is a band-aid for now